### PR TITLE
feat: localStorage persistence, layout & CSS refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,4 +222,6 @@ tags
 .history
 .ionide
 
+.claude/
+
 # End of https://www.toptal.com/developers/gitignore/api/vim,macos,svelte,visualstudiocode,node

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run dev       # Start dev server (localhost:5173, SPA routing via historyApiFallback)
+npm run build     # Build to ./dist
+npm run preview   # Preview the production build
+```
+
+No test runner is configured.
+
+## Architecture
+
+**shqipee** is a Svelte 5 SPA that transliterates Albanian Latin text into three historical scripts — Elbasan, Vithkuqi, and Todhri — and back. Routing is handled by `svelte-routing` (client-side only; `historyApiFallback: true` in Vite makes deep links work in dev).
+
+### Data flow
+
+```
+src/data/mappings.js          — character maps (Latin → Unicode codepoints)
+src/utils/scriptTypes.js      — ScriptType enum { ELBASAN, VITHKUQI, TODHRI }
+src/routes/{elbasan,vithkuqi,todhri}.svelte  — one route per script, passes scriptType prop down
+src/components/Transliterator.svelte         — core logic: regex-replace transliteration, swap direction, localStorage persistence
+src/components/TopSection.svelte             — heading + Navbar
+src/components/Navbar.svelte                 — links to the three routes
+src/components/BottomContent.svelte          — supplementary info per script
+```
+
+### Key transliteration details
+
+- Mapping keys in `mappings.js` are ordered longest-first so the `RegExp(Object.keys(mapping).join('|'))` pattern matches multi-character digraphs/trigraphs before single letters.
+- Elbasan and Todhri are always lowercased before transliteration; Vithkuqi is case-sensitive (separate uppercase and lowercase entries in the map).
+- `flipMapping()` in `Transliterator.svelte` inverts a mapping for script→Latin direction.
+- `localStorage` persists `transliterationInput` and `transliterationIsLatin` across page reloads.
+
+### Custom font
+
+`src/assets/TodhriFont.ttf` is loaded globally in `src/app.css` for the Todhri script rendering.
+
+### Routing
+
+`App.svelte` uses `<Router>` with three `<Route>` entries (`/`, `/vithkuqi`, `/todhri`). The Navbar uses `svelte-routing`'s `use:link` directive and `useLocation()` to highlight the active route.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shqipee",
-  "version": "2.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shqipee",
-      "version": "2.1.0",
+      "version": "2.0.0",
       "dependencies": {
         "@sveltejs/kit": "^2.11.1",
         "svelte-routing": "^2.13.0",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -5,13 +5,11 @@
   import Todhri from "./routes/todhri.svelte";
 </script>
 
-<main>
-  <Router>
-    <Route path="/" component={Elbasan} />
-    <Route path="/vithkuqi" component={Vithkuqi} />
-    <Route path="/todhri" component={Todhri} />
-  </Router>
-</main>
+<Router>
+  <Route path="/" component={Elbasan} />
+  <Route path="/vithkuqi" component={Vithkuqi} />
+  <Route path="/todhri" component={Todhri} />
+</Router>
 
 <footer></footer>
 

--- a/src/app.css
+++ b/src/app.css
@@ -1,19 +1,20 @@
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+Elbasan&family=Noto+Sans+Vithkuqi:wght@400..700&family=Roboto:wght@500&display=swap');
 
 @font-face {
-  font-family: "Trodhi";
+  font-family: "Todhri";
   src: url(./assets/TodhriFont.ttf);
 }
 
-/* CSS Custom Properties (Variables) */
+/* CSS Custom Properties */
 :root {
-  /* Farben */
+  /* Colors */
   --color-background: #DBE1D5;
+  --color-background-dark: #121212;
   --color-text: inherit;
   --color-border: #bdc3c7;
   
-  /* Typografie */
-  --font-family-primary: "Roboto", "Noto Sans Vithkuqi", "Noto Sans Elbasan", Trodhi, sans-serif;
+  /* Typography */
+  --font-family-primary: "Roboto", "Noto Sans Vithkuqi", "Noto Sans Elbasan", Todhri, sans-serif;
   --font-size-h1-desktop: 92px;
   --font-size-h1-mobile: 64px;
   --font-size-h2-desktop: 64px;
@@ -28,7 +29,7 @@
   /* Breakpoints */
   --breakpoint-mobile: 768px;
   
-  /* Abstände */
+  /* Spacing */
   --space-xs: 0.25rem;   /* 4px */
   --space-sm: 0.5rem;    /* 8px */
   --space-md: 0.75rem;   /* 12px */
@@ -47,12 +48,12 @@
   --radius-xl: 0.75rem;   /* 12px */
   --radius-2xl: 1rem;     /* 16px */
   
-  /* Schatten */
+  /* Shadows */
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.06);
   --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.07), 0 2px 4px rgba(0, 0, 0, 0.06);
   --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.1), 0 4px 6px rgba(0, 0, 0, 0.05);
   
-  /* Transitionen */
+  /* Transitions */
   --transition-fast: 150ms ease-in-out;
   --transition-normal: 300ms ease-in-out;
   --transition-slow: 500ms ease-in-out;

--- a/src/app.css
+++ b/src/app.css
@@ -9,10 +9,13 @@
 :root {
   /* Colors */
   --color-background: #DBE1D5;
-  --color-background-dark: #121212;
-  --color-text: inherit;
+  --color-text: #000000;
   --color-border: #bdc3c7;
   
+  /* Dark Mode Colors */
+  --color-background-dark: #000000;
+  --color-text-dark: #f8f9fa;
+
   /* Typography */
   --font-family-primary: "Roboto", "Noto Sans Vithkuqi", "Noto Sans Elbasan", Todhri, sans-serif;
   --font-size-h1-desktop: 92px;

--- a/src/app.css
+++ b/src/app.css
@@ -82,6 +82,10 @@ main {
   margin: 0 auto;
   padding: var(--container-padding-desktop);
   box-sizing: border-box;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 h1 {

--- a/src/app.css
+++ b/src/app.css
@@ -5,9 +5,62 @@
   src: url(./assets/TodhriFont.ttf);
 }
 
+/* CSS Custom Properties (Variables) */
+:root {
+  /* Farben */
+  --color-background: #DBE1D5;
+  --color-text: inherit;
+  --color-border: #bdc3c7;
+  
+  /* Typografie */
+  --font-family-primary: "Roboto", "Noto Sans Vithkuqi", "Noto Sans Elbasan", Trodhi, sans-serif;
+  --font-size-h1-desktop: 92px;
+  --font-size-h1-mobile: 64px;
+  --font-size-h2-desktop: 64px;
+  --font-size-h2-mobile: 48px;
+  --line-height-h1: 0.9em;
+  
+  /* Layout */
+  --container-max-width: 1600px;
+  --container-padding-desktop: 20px 80px;
+  --container-padding-mobile: 10px 20px;
+  
+  /* Breakpoints */
+  --breakpoint-mobile: 768px;
+  
+  /* Abstände */
+  --space-xs: 0.25rem;   /* 4px */
+  --space-sm: 0.5rem;    /* 8px */
+  --space-md: 0.75rem;   /* 12px */
+  --space-lg: 1rem;      /* 16px */
+  --space-xl: 1.5rem;    /* 24px */
+  --space-2xl: 2rem;     /* 32px */
+  --space-3xl: 3rem;     /* 48px */
+  --space-4xl: 4rem;     /* 64px */
+  --space-5xl: 6rem;     /* 96px */
+  --space-6xl: 8rem;     /* 128px */
+  
+  /* Border Radius */
+  --radius-sm: 0.25rem;   /* 4px */
+  --radius-md: 0.375rem;  /* 6px */
+  --radius-lg: 0.5rem;    /* 8px */
+  --radius-xl: 0.75rem;   /* 12px */
+  --radius-2xl: 1rem;     /* 16px */
+  
+  /* Schatten */
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.06);
+  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.07), 0 2px 4px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.1), 0 4px 6px rgba(0, 0, 0, 0.05);
+  
+  /* Transitionen */
+  --transition-fast: 150ms ease-in-out;
+  --transition-normal: 300ms ease-in-out;
+  --transition-slow: 500ms ease-in-out;
+}
+
 * {
-  background: #DBE1D5;
-  font-family: "Roboto", "Noto Sans Vithkuqi", "Noto Sans Elbasan", Trodhi, sans-serif;
+  background: var(--color-background);
+  font-family: var(--font-family-primary);
   max-height: 100%;
   margin: 0;
   padding: 0;
@@ -15,35 +68,35 @@
 }
 
 h2 {
-  font-size: 64px;
+  font-size: var(--font-size-h2-desktop);
   margin: 0;
 }
 
 main {
   display: relative;
-  max-width: 1600px;
+  max-width: var(--container-max-width);
   margin: 0 auto;
-  padding: 20px 80px;
+  padding: var(--container-padding-desktop);
   box-sizing: border-box;
 }
 
 h1 {
-  font-size: 92px;
-  line-height: 0.9em;
+  font-size: var(--font-size-h1-desktop);
+  line-height: var(--line-height-h1);
   padding-bottom: 5%;
 }
 
 @media (max-width: 768px) {
   h2 {
-    font-size: 48px;
+    font-size: var(--font-size-h2-mobile);
   }
 
   h1 {
-    font-size: 64px;
+    font-size: var(--font-size-h1-mobile);
     text-align: left;
   }
 
   main {
-    padding: 10px 20px;
+    padding: var(--container-padding-mobile);
   }
 }

--- a/src/app.css
+++ b/src/app.css
@@ -77,7 +77,6 @@ h2 {
 }
 
 main {
-  display: relative;
   max-width: var(--container-max-width);
   margin: 0 auto;
   padding: var(--container-padding-desktop);

--- a/src/app.css
+++ b/src/app.css
@@ -79,12 +79,8 @@ h2 {
 main {
   max-width: var(--container-max-width);
   margin: 0 auto;
-  padding: var(--container-padding-desktop);
+  padding: 60px 200px 20px 80px;
   box-sizing: border-box;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
 }
 
 h1 {

--- a/src/components/BottomContent.svelte
+++ b/src/components/BottomContent.svelte
@@ -53,7 +53,8 @@ export let scriptType;
   .bottom-content {
     display: flex;
     flex-direction: row;
-    gap: 20%;
+    justify-content: space-between;
+    gap: 5%;
   }
 
   #sign {
@@ -66,9 +67,8 @@ export let scriptType;
   .text-left {
     display: flex;
     flex-direction: row;
-    flex: 2;
+    flex: 1;
     min-width: 300px;
-    max-width: 450px;
   }
 
   .text-left-item {
@@ -79,9 +79,8 @@ export let scriptType;
   .text-right {
     display: flex;
     flex-direction: column;
-    flex: 2;
+    flex: 1;
     min-width: 300px;
-    max-width: 450px;
   }
 
   a,

--- a/src/components/BottomContent.svelte
+++ b/src/components/BottomContent.svelte
@@ -51,24 +51,22 @@ export let scriptType;
   }
 
   .bottom-content {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    gap: 5%;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
   }
 
   #sign {
     font-size: 120px;
     color: #c3181e;
     line-height: 1em;
-    margin: auto;
+    margin-right: 8px;
+    align-self: flex-start;
   }
 
   .text-left {
     display: flex;
     flex-direction: row;
-    flex: 1;
-    min-width: 300px;
+    max-width: 450px;
   }
 
   .text-left-item {
@@ -79,8 +77,7 @@ export let scriptType;
   .text-right {
     display: flex;
     flex-direction: column;
-    flex: 1;
-    min-width: 300px;
+    padding-left: 65px;
   }
 
   a,
@@ -91,7 +88,7 @@ export let scriptType;
 
   @media (max-width: 1200px) {
     .bottom-content {
-      flex-direction: column;
+      grid-template-columns: 1fr;
     }
 
     .text-right {

--- a/src/components/Navbar.svelte
+++ b/src/components/Navbar.svelte
@@ -27,7 +27,6 @@
     align-items: center;
     gap: 30px;
     margin-bottom: 20px;
-    background-color: #DBE1D5;
   }
 
   .navbar a {

--- a/src/components/TopSection.svelte
+++ b/src/components/TopSection.svelte
@@ -31,7 +31,7 @@
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
-    padding-bottom: 10%;
+    padding-bottom: 5%;
   }
 
   .headingTop {

--- a/src/components/Transliterator.svelte
+++ b/src/components/Transliterator.svelte
@@ -146,16 +146,16 @@ onMount(() => {
   .input-div {
     display: flex;
     flex-direction: row;
-    padding-right: 20%;
     padding-bottom: 5%;
+    width: 100%;
+    justify-content: space-between;
   }
 
   .input-container {
     display: flex;
     flex-direction: column;
-    flex: 2;
+    flex: 1;
     min-width: 300px;
-    width: 300px;
   }
 
   .input-header {
@@ -208,10 +208,10 @@ onMount(() => {
   .swap-container {
     display: flex;
     flex-direction: column;
-    flex: 1;
     align-items: center;
-    width: 300px;
-    min-width: 300px;
+    justify-content: center;
+    width: 100px;
+    min-width: 100px;
   }
 
   .swap-button {
@@ -232,8 +232,7 @@ onMount(() => {
   .output-container {
     display: flex;
     flex-direction: column;
-    flex: 2;
-    width: 300px;
+    flex: 1;
     min-width: 300px;
   }
 

--- a/src/components/Transliterator.svelte
+++ b/src/components/Transliterator.svelte
@@ -2,6 +2,7 @@
 import {copy} from 'svelte-copy'
 import {elbasanMapping, vithkuqiMapping, todhriMapping} from '../data/mappings.js';
 import {ScriptType} from '../utils/scriptTypes.js';
+import { onMount } from 'svelte';
 export let scriptType;
 
 let currentMapping
@@ -56,13 +57,17 @@ const swapDirection = () => {
     }
 
     // reset input and output
-    inputText = "";
-    outputText = "";
+    inputText = outputText;
+    localStorage.setItem('transliterationInput', inputText);
+    localStorage.setItem('transliterationIsLatin', String(isLatinToScript));
+    outputText = transliterate(inputText);
 };
 
 // input handler: transliterate text and update output
 const handleInput = (event) => {
     inputText = event.target.value;
+    localStorage.setItem('transliterationInput', inputText);
+    localStorage.setItem('transliterationIsLatin', String(isLatinToScript));
     outputText = transliterate(inputText);
 };
 
@@ -71,11 +76,22 @@ const pasteFromClipboard = async () => {
     try {
         const clipboardText = await navigator.clipboard.readText();
         inputText = clipboardText;
+        localStorage.setItem('transliterationInput', inputText);
+        localStorage.setItem('transliterationIsLatin', String(isLatinToScript));
         outputText = transliterate(inputText);
     } catch (error) {
         console.error("Error accessing clipboard: ", error);
     }
 };
+
+onMount(() => {
+    const savedInput = localStorage.getItem('transliterationInput');
+    const savedIsLatin = localStorage.getItem('transliterationIsLatin') === 'true';
+    if (savedInput && savedIsLatin) {
+        inputText = savedInput;
+        outputText = transliterate(inputText);
+    }
+});
 </script>
 
 <div class="switchArea">

--- a/src/components/Transliterator.svelte
+++ b/src/components/Transliterator.svelte
@@ -43,7 +43,15 @@ const transliterate = (word) => {
     return word.replace(pattern, match => activeMapping[match]);
 };
 
-// swap direction
+// persist state to localStorage, ignoring errors (quota exceeded, private mode, etc.)
+const saveToStorage = (input, isLatin) => {
+    try {
+        localStorage.setItem('transliterationInput', input);
+        localStorage.setItem('transliterationIsLatin', String(isLatin));
+    } catch (_) {}
+};
+
+// swap direction: carry over the previous output as the new input and transliterate
 const swapDirection = () => {
     isLatinToScript = !isLatinToScript;
 
@@ -56,19 +64,20 @@ const swapDirection = () => {
       outputTitle = "latin";
     }
 
-    // carry over the previous output as the new input and transliterate in the new direction
     inputText = outputText;
-    localStorage.setItem('transliterationInput', inputText);
-    localStorage.setItem('transliterationIsLatin', String(isLatinToScript));
+    saveToStorage(inputText, isLatinToScript);
     outputText = transliterate(inputText);
 };
 
-// input handler: transliterate text and update output
+// debounce timer for localStorage writes
+let saveDebounceTimer;
+
+// input handler: transliterate text immediately; debounce the localStorage write
 const handleInput = (event) => {
     inputText = event.target.value;
-    localStorage.setItem('transliterationInput', inputText);
-    localStorage.setItem('transliterationIsLatin', String(isLatinToScript));
     outputText = transliterate(inputText);
+    clearTimeout(saveDebounceTimer);
+    saveDebounceTimer = setTimeout(() => saveToStorage(inputText, isLatinToScript), 300);
 };
 
 // paste text from clipboard
@@ -76,8 +85,7 @@ const pasteFromClipboard = async () => {
     try {
         const clipboardText = await navigator.clipboard.readText();
         inputText = clipboardText;
-        localStorage.setItem('transliterationInput', inputText);
-        localStorage.setItem('transliterationIsLatin', String(isLatinToScript));
+        saveToStorage(inputText, isLatinToScript);
         outputText = transliterate(inputText);
     } catch (error) {
         console.error("Error accessing clipboard: ", error);
@@ -85,15 +93,17 @@ const pasteFromClipboard = async () => {
 };
 
 onMount(() => {
-    const savedInput = localStorage.getItem('transliterationInput');
-    const savedIsLatinRaw = localStorage.getItem('transliterationIsLatin');
-    if (savedInput !== null && savedIsLatinRaw !== null) {
-        isLatinToScript = savedIsLatinRaw === 'true';
-        inputTitle = isLatinToScript ? 'latin' : scriptType;
-        outputTitle = isLatinToScript ? scriptType : 'latin';
-        inputText = savedInput;
-        outputText = transliterate(inputText);
-    }
+    try {
+        const savedInput = localStorage.getItem('transliterationInput');
+        const savedIsLatinRaw = localStorage.getItem('transliterationIsLatin');
+        if (savedInput !== null && savedIsLatinRaw !== null) {
+            isLatinToScript = savedIsLatinRaw === 'true';
+            inputTitle = isLatinToScript ? 'latin' : scriptType;
+            outputTitle = isLatinToScript ? scriptType : 'latin';
+            inputText = savedInput;
+            outputText = transliterate(inputText);
+        }
+    } catch (_) {}
 });
 </script>
 

--- a/src/components/Transliterator.svelte
+++ b/src/components/Transliterator.svelte
@@ -86,8 +86,11 @@ const pasteFromClipboard = async () => {
 
 onMount(() => {
     const savedInput = localStorage.getItem('transliterationInput');
-    const savedIsLatin = localStorage.getItem('transliterationIsLatin') === 'true';
-    if (savedInput && savedIsLatin) {
+    const savedIsLatinRaw = localStorage.getItem('transliterationIsLatin');
+    if (savedInput !== null && savedIsLatinRaw !== null) {
+        isLatinToScript = savedIsLatinRaw === 'true';
+        inputTitle = isLatinToScript ? 'latin' : scriptType;
+        outputTitle = isLatinToScript ? scriptType : 'latin';
         inputText = savedInput;
         outputText = transliterate(inputText);
     }

--- a/src/components/Transliterator.svelte
+++ b/src/components/Transliterator.svelte
@@ -96,12 +96,8 @@ const pasteFromClipboard = async () => {
 
 onMount(() => {
     try {
-        if (savedInput !== null) {
-            if (savedIsLatinRaw === 'true') {
-                isLatinToScript = true;
-            } else if (savedIsLatinRaw === 'false') {
-                isLatinToScript = false;
-            }
+        const savedInput = localStorage.getItem('transliterationInput');
+        const savedIsLatinRaw = localStorage.getItem('transliterationIsLatin');
         if (savedInput !== null && savedIsLatinRaw !== null) {
             isLatinToScript = savedIsLatinRaw === 'true';
             inputTitle = isLatinToScript ? 'latin' : scriptType;
@@ -159,7 +155,6 @@ onMount(() => {
 
 <style>
   .switchArea {
-    display: relative;
     flex-direction: row;
     gap: 3%;
   }

--- a/src/components/Transliterator.svelte
+++ b/src/components/Transliterator.svelte
@@ -48,7 +48,9 @@ const saveToStorage = (input, isLatin) => {
     try {
         localStorage.setItem('transliterationInput', input);
         localStorage.setItem('transliterationIsLatin', String(isLatin));
-    } catch (_) {}
+    } catch (e) {
+        console.warn('localStorage unavailable, state will not be persisted:', e);
+    }
 };
 
 // swap direction: carry over the previous output as the new input and transliterate
@@ -103,7 +105,9 @@ onMount(() => {
             inputText = savedInput;
             outputText = transliterate(inputText);
         }
-    } catch (_) {}
+    } catch (e) {
+        console.warn('localStorage unavailable, saved state could not be restored:', e);
+    }
 });
 </script>
 

--- a/src/components/Transliterator.svelte
+++ b/src/components/Transliterator.svelte
@@ -96,8 +96,12 @@ const pasteFromClipboard = async () => {
 
 onMount(() => {
     try {
-        const savedInput = localStorage.getItem('transliterationInput');
-        const savedIsLatinRaw = localStorage.getItem('transliterationIsLatin');
+        if (savedInput !== null) {
+            if (savedIsLatinRaw === 'true') {
+                isLatinToScript = true;
+            } else if (savedIsLatinRaw === 'false') {
+                isLatinToScript = false;
+            }
         if (savedInput !== null && savedIsLatinRaw !== null) {
             isLatinToScript = savedIsLatinRaw === 'true';
             inputTitle = isLatinToScript ? 'latin' : scriptType;

--- a/src/components/Transliterator.svelte
+++ b/src/components/Transliterator.svelte
@@ -56,7 +56,7 @@ const swapDirection = () => {
       outputTitle = "latin";
     }
 
-    // reset input and output
+    // carry over the previous output as the new input and transliterate in the new direction
     inputText = outputText;
     localStorage.setItem('transliterationInput', inputText);
     localStorage.setItem('transliterationIsLatin', String(isLatinToScript));

--- a/src/routes/elbasan.svelte
+++ b/src/routes/elbasan.svelte
@@ -10,6 +10,8 @@
   <title>shqip.ee | elbasan</title> 
 </svelte:head>
 
-<TopSection scriptType={scriptType} />
-<Transliterator scriptType={scriptType} />
-<BottomContent scriptType={scriptType} />
+<main>
+  <TopSection scriptType={scriptType} />
+  <Transliterator scriptType={scriptType} />
+  <BottomContent scriptType={scriptType} />
+</main>

--- a/src/routes/todhri.svelte
+++ b/src/routes/todhri.svelte
@@ -10,6 +10,8 @@
     <title>shqip.ee | todhri</title> 
   </svelte:head>
   
+<main>
   <TopSection scriptType={scriptType} />
   <Transliterator scriptType={scriptType} />
   <BottomContent scriptType={scriptType} />
+</main>

--- a/src/routes/vithkuqi.svelte
+++ b/src/routes/vithkuqi.svelte
@@ -10,6 +10,8 @@
   <title>shqip.ee | vithkuqi</title> 
 </svelte:head>
 
-<TopSection scriptType={scriptType} />
-<Transliterator scriptType={scriptType} />
-<BottomContent scriptType={scriptType} />
+<main>
+  <TopSection scriptType={scriptType} />
+  <Transliterator scriptType={scriptType} />
+  <BottomContent scriptType={scriptType} />
+</main>


### PR DESCRIPTION
## Summary

### Transliterator
- Input text and direction (Latin↔script) are now persisted to `localStorage` and restored on page load — works for both directions
- Swap now carries the current output over as the new input instead of resetting both fields
- `localStorage` writes are debounced (300ms during typing) and wrapped in try/catch for private mode / quota errors
- Swap container resized from 300px to 100px; left/right columns rebalanced with `flex: 1` and `justify-content: space-between`

### Layout
- Removed duplicate `<main>` wrapper from `App.svelte`; each route now owns its own `<main>` so global `main` CSS applies exactly once
- `app.css`: fixed invalid `display: relative` on `main`, adjusted padding to `60px 200px 20px 80px` for better spacing and visual width
- `TopSection`: reduced `padding-bottom` from 10% to 5%
- `Navbar`: removed redundant explicit background-color

### BottomContent
- Switched from flexbox with `gap: 20%` to CSS grid (`1fr 1fr`) so the right column aligns precisely with the transliterator's right column
- `#sign` (!) is now top-aligned instead of vertically centered
- `padding-left: 65px` on `.text-right` to match the visual offset of the transliterator's output column start

### CSS
- Added full set of CSS custom properties (colors, typography, spacing, radius, shadows, transitions) to `:root`
- Fixed font-family name from `"Trodhi"` to `"Todhri"` throughout

### Docs & config
- Added `CLAUDE.md` with dev commands and architecture overview
- Added `.claude/` to `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)